### PR TITLE
allow to change destination file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
    * download
    * @param {String | Array} url
    * @param {String} dest
+   * @param {Object} options
    * return {EventEmitter}
    */
 
@@ -30,6 +31,12 @@
     .on('invalid', function (e) {
       console.log(e.url + ' is invalid');
     })
+
+  // change destination file name
+  download('http://url.com/some?long=query&with=parameters', './', {outputName:'my_file.jpg'})
+    .on('done', function () {
+    console.log('File saved as my_file.jpg');
+  });
 ```
 
 ## License

--- a/lib/download.js
+++ b/lib/download.js
@@ -14,9 +14,18 @@
    */
   module.exports = function (url, dest, opts) {
     url = Array.isArray(url) ? url : [url];
+    // allow for customization of output file name
+    var baseName = path.basename(url)
+    if(opts && opts.outputName) {
+      if(url.length != 1) {
+        throw new Error("'outputName' only supported for single file download");
+      }
+      baseName = opts.outputName
+    }
+
     var emitter = new EventEmitter();
     eachAsync(url, function (url, i, done) {
-      var file = path.join(dest, path.basename(url))
+      var file = path.join(dest, baseName)
         , stream;
       valid(url).on('data', function (err, chunk) {
         if (err) emitter.emit('error', err);


### PR DESCRIPTION
normally on a download we calculate the filename based on the source
url; this pull requests allows an `outputName` to be specified in the
`options` parameter which will specify the output file name rather than
extract it from the original url