### PR TITLE
fixed bug with url being an array not a string

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -15,16 +15,19 @@
   module.exports = function (url, dest, opts) {
     url = Array.isArray(url) ? url : [url];
     // allow for customization of output file name
-    var baseName = path.basename(url)
     if (opts && opts.outputName) {
       if (url.length !== 1) {
         throw new Error("'outputName' only supported for single file download");
       }
-      baseName = opts.outputName
     }
 
     var emitter = new EventEmitter();
     eachAsync(url, function (url, i, done) {
+      // allow for customization of output file name
+      var baseName = path.basename(url)
+      if (opts && opts.outputName) {
+        baseName = opts.outputName
+      }
       var file = path.join(dest, baseName)
         , stream;
       valid(url).on('data', function (err, chunk) {


### PR DESCRIPTION
just realised that my last pull request actually introduced a bug which was preventing this from working.
The `url` in the previous commit was an array not a string so the whole thing was failing.
Changed now and it works fine.